### PR TITLE
Create multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Technical issue with the Magento 2 core components
+
+---
+
+<!---
+Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
+-->
+
+### Preconditions
+<!---
+Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
+-->
+1.
+2.
+
+### Steps to reproduce
+<!---
+Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
+-->
+1.
+2.
+
+### Expected result
+<!--- Tell us what do you expect to happen. -->
+1. [Screenshots, logs or description]
+2.
+
+### Actual result
+<!--- Tell us what happened instead. Include error messages and issues. -->
+1. [Screenshots, logs or description]
+2.

--- a/.github/ISSUE_TEMPLATE/developer-experience-issue.md
+++ b/.github/ISSUE_TEMPLATE/developer-experience-issue.md
@@ -1,0 +1,18 @@
+---
+name: Developer experience issue
+about: Issues related to customization, extensibility, modularity
+
+---
+
+<!---
+Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
+-->
+
+### Summary
+<!--- Describe the issue you are experiencing. Include general information, error messages, environments, and so on. -->
+
+### Examples
+<!--- Provide code examples or a patch with a test (recommended) to clearly indicate the problem. -->
+
+### Proposed solution
+<!--- Suggest your potential solutions for this issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Please consider reporting directly to https://github.com/magento/community-features
+
+---
+
+<!---
+Important: This repository is intended only for Magento 2 Technical Issues. Enter Feature Requests at https://github.com/magento/community-features. Project stakeholders monitor and manage requests. Feature requests entered using this form may be moved to the forum.
+-->
+
+### Description
+<!--- Describe the feature you would like to add. -->
+
+### Expected behavior
+<!--- What is the expected behavior of this feature? How is it going to work? -->
+
+### Benefits
+<!--- How do you think this feature would improve Magento? -->
+
+### Additional information
+<!--- What other information can you provide about the desired feature? -->


### PR DESCRIPTION
To improve flow for submitting an issue to Magento 2 GitHub issue templates for different situations are added.