### PR TITLE
Allow loading of MDE resources from the correct directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -315,5 +315,16 @@
             "Magento\\TestFramework\\Utility\\": "dev/tests/static/framework/Magento/TestFramework/Utility/"
         }
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../*"
+        },
+        {
+            "type": "path",
+            "url": "../*/*"
+        }
+    ]
 }

--- a/lib/internal/Magento/Framework/Code/GeneratedFiles.php
+++ b/lib/internal/Magento/Framework/Code/GeneratedFiles.php
@@ -19,7 +19,7 @@ class GeneratedFiles
     /**
      * Separator literal to assemble timer identifier from timer names
      */
-    const REGENERATE_FLAG = '/var/.regenerate';
+    const REGENERATE_FLAG = 'var/.regenerate';
 
     /**
      * @var DirectoryList

--- a/lib/internal/Magento/Framework/Filesystem/Directory/PathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/PathValidator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Filesystem\Directory;
 
+use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Phrase;
@@ -60,6 +61,13 @@ class PathValidator implements PathValidatorInterface
         if (mb_strpos($actualPath, $realDirectoryPath) !== 0
             && $path .DIRECTORY_SEPARATOR !== $realDirectoryPath
         ) {
+            $componentsPaths = (new ComponentRegistrar())->getPaths(ComponentRegistrar::MODULE);
+            foreach ($componentsPaths as $componentPath) {
+                if (mb_strpos($actualPath, $componentPath) === 0) {
+                    return;
+                }
+            }
+
             throw new ValidatorException(
                 new Phrase(
                     'Path "%1" cannot be used with directory "%2"',

--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -861,9 +861,9 @@ class File implements DriverInterface
     public function getAbsolutePath($basePath, $path, $scheme = null)
     {
         // check if the path given is already an absolute path containing the
-        // basepath. so if the basepath starts at position 0 in the path, we
-        // must not concatinate them again because path is already absolute.
-        if (0 === strpos($path, $basePath)) {
+        // leading slash. so if the basepath starts at position 0 in the path, we
+        // must not concatenate them again because path is already absolute.
+        if (strpos($path, '/') === 0) {
             return $this->getScheme($scheme) . $path;
         }
 

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Element\Template\File;
 
-use \Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Component\ComponentRegistrar;
 
 /**
@@ -110,9 +110,21 @@ class Validator
                     || $this->isPathInDirectories($filename, $this->moduleDirs)
                     || $this->isPathInDirectories($filename, $this->_themesDir)
                     || $this->_isAllowSymlinks)
-                && $this->getRootDirectory()->isFile($this->getRootDirectory()->getRelativePath($filename));
+                && $this->_filesystem->getDirectoryReadByPath($this->getDirectoryByFile($filename))->isFile($filename);
         }
         return $this->_templatesValidationResults[$filename];
+    }
+
+    /**
+     * Extract directory path from file name.
+     *
+     * @param string $filename
+     * @return string
+     */
+    private function getDirectoryByFile(string $filename): string
+    {
+        $filename = explode("/", $filename, -1);
+        return implode("/", $filename);
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Element\Template\File;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
+use \Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Component\ComponentRegistrar;
 
 /**
@@ -110,21 +110,9 @@ class Validator
                     || $this->isPathInDirectories($filename, $this->moduleDirs)
                     || $this->isPathInDirectories($filename, $this->_themesDir)
                     || $this->_isAllowSymlinks)
-                && $this->_filesystem->getDirectoryReadByPath($this->getDirectoryByFile($filename))->isFile($filename);
+                && $this->getRootDirectory()->isFile($this->getRootDirectory()->getRelativePath($filename));
         }
         return $this->_templatesValidationResults[$filename];
-    }
-
-    /**
-     * Extract directory path from file name.
-     *
-     * @param string $filename
-     * @return string
-     */
-    private function getDirectoryByFile(string $filename): string
-    {
-        $filename = explode("/", $filename, -1);
-        return implode("/", $filename);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In order to support desired MDE project structure – file path validation logic has been adjusted and composer path repositories were added.
See [MDE Project structure design](https://github.com/magento/architecture/blob/master/design-documents/mde-project-structure.md) for more information

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [MAGETWO-95040](https://jira.corp.magento.com/browse/MAGETWO-95040): Allow templates loading outside of the project Workaround
2. [MAGETWO-95041](https://jira.corp.magento.com/browse/MAGETWO-95041): Add support for MDEs via composer path repository

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set up project based on desired MDE structure
2. Verify that MDE can load it's resources from outside of Magento root

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
